### PR TITLE
Set default vm mem

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -70,8 +70,8 @@ Vagrant.configure("2") do |config|
   subdomains << '*' if RUBY_PLATFORM =~ /darwin/
   config.hostsupdater.aliases = subdomains.map { |s| [s,VAGRANT_APP_DOMAIN].compact * '.' }
 
-	config.vm.provider :virtualbox do |vm|
-		vm.customize ["modifyvm", :id, "--name", VAGRANT_APP_DOMAIN]
+  config.vm.provider :virtualbox do |vm|
+    vm.customize ["modifyvm", :id, "--name", VAGRANT_APP_DOMAIN]
     vm.customize ["modifyvm", :id, "--memory", ENV['VM_MEM'] ? ENV['VM_MEM'].to_i : 4096]
 
     # vagrant-faster сам подбирает нужные парметры

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -72,9 +72,7 @@ Vagrant.configure("2") do |config|
 
 	config.vm.provider :virtualbox do |vm|
 		vm.customize ["modifyvm", :id, "--name", VAGRANT_APP_DOMAIN]
-    if ENV['VM_MEM']
-      vm.customize ["modifyvm", :id, "--memory", [ENV['VM_MEM'].to_i, 4096].max]
-    end
+    vm.customize ["modifyvm", :id, "--memory", ENV['VM_MEM'] ? ENV['VM_MEM'].to_i : 4096]
 
     # vagrant-faster сам подбирает нужные парметры
     # на mac pro 4 cpu, 8Gb отдает 2 cpu и 2Gb


### PR DESCRIPTION
после удаления vagrant-faster переменная ENV['VM_MEM'] стала пуста из за чего не срабатывало условие 
if ENV['VM_MEM']
      vm.customize ["modifyvm", :id, "--memory", [ENV['VM_MEM'].to_i, 4096].max]
end
и память не устанавливалась. установка вагранта заканчивалась ошибкой.
сделал 4 по умолчанию либо можно установить руками сколько угодно
